### PR TITLE
Make VariantData url public

### DIFF
--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -453,7 +453,6 @@ impl VariantData {
     pub fn get_url(&self) -> VariantDataUrl {
         self.url
     }
-
 }
 
 /// A single segment, representing a part of a video stream.

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -195,10 +195,14 @@ pub struct VariantData {
     pub fps: f64,
     pub codecs: String,
 
-    pub url: VariantDataUrl,
+    url: VariantDataUrl,
 }
 
 impl VariantData {
+    pub(crate) async fn get_url() -> Result<VariantDataUrl>{
+    Ok(self.url)
+    }
+    
     #[cfg(feature = "hls-stream")]
     pub(crate) async fn from_hls_master(
         executor: Arc<Executor>,

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,7 +199,7 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    pub(crate) async fn get_url() -> Result<VariantDataUrl>{
+    pub(crate) async fn get_url(&self) -> Result<VariantDataUrl>{
     Ok(self.url)
     }
     

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -451,7 +451,7 @@ impl VariantData {
     }
 
     pub fn get_url(&self) -> VariantDataUrl {
-        self.url
+        self.url.clone()
     }
 }
 

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -419,6 +419,17 @@ impl VariantData {
         Ok(segments)
     }
 
+    // Get the m3u8 url if you want to use ffmpeg to handle all the download process
+    // It can be faster to download yourself segment by segment
+    #[cfg(feature = "hls-stream")]
+    pub fn hls_get_master_url(&self) -> Result<String> {
+        #[allow(irrefutable_let_patterns)]
+        let VariantDataUrl::Hls { url } = &self.url else {
+            return Err(CrunchyrollError::Internal("variant url should be hls".into()))
+        };
+        Ok(url.to_string())
+    }
+
     #[cfg(feature = "dash-stream")]
     async fn dash_segments(&self) -> Result<Vec<VariantSegment>> {
         #[allow(irrefutable_let_patterns)]
@@ -448,10 +459,6 @@ impl VariantData {
         }
 
         Ok(segments)
-    }
-
-    pub fn get_url(&self) -> VariantDataUrl {
-        self.url.clone()
     }
 }
 

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,9 +199,6 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    pub fn get_url(&self) -> VariantDataUrl{
-        self.url
-    }
     
     #[cfg(feature = "hls-stream")]
     pub(crate) async fn from_hls_master(
@@ -453,6 +450,11 @@ impl VariantData {
 
         Ok(segments)
     }
+    
+    pub fn get_url(&self) -> VariantDataUrl {
+        self.url
+    }
+
 }
 
 /// A single segment, representing a part of a video stream.

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -195,7 +195,7 @@ pub struct VariantData {
     pub fps: f64,
     pub codecs: String,
 
-    url: VariantDataUrl,
+    pub url: VariantDataUrl,
 }
 
 impl VariantData {

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,7 +199,6 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    
     #[cfg(feature = "hls-stream")]
     pub(crate) async fn from_hls_master(
         executor: Arc<Executor>,
@@ -450,7 +449,7 @@ impl VariantData {
 
         Ok(segments)
     }
-    
+
     pub fn get_url(&self) -> VariantDataUrl {
         self.url
     }

--- a/src/media/streaming.rs
+++ b/src/media/streaming.rs
@@ -199,8 +199,8 @@ pub struct VariantData {
 }
 
 impl VariantData {
-    pub(crate) async fn get_url(&self) -> Result<VariantDataUrl>{
-    Ok(self.url)
+    pub fn get_url(&self) -> VariantDataUrl{
+        self.url
     }
     
     #[cfg(feature = "hls-stream")]


### PR DESCRIPTION
Making the VariantData.url public to allow for ffmpeg handling the download from m3u8 file completely by itself.